### PR TITLE
feat: 조력자에게 실패 알림이 10분 간격으로 보내지게끔 수정

### DIFF
--- a/supabase/functions/notification-failed-missions/_types.ts
+++ b/supabase/functions/notification-failed-missions/_types.ts
@@ -2,6 +2,7 @@ export interface MissionHistoryData {
   id: number;
   done_at: string;
   mission_at: string;
+  last_failed_noti_sent_at: string | null;
   mission_time: {
     id: number;
     challenger_supporter_id: string;
@@ -35,6 +36,7 @@ export interface CombinedMissionData {
   id: number;
   done_at: string | null;
   mission_at: string;
+  last_failed_noti_sent_at: string | null;
   mission_time: {
     id: number;
     challenger_supporter_id: string;

--- a/supabase/functions/notification-failed-missions/deno.lock
+++ b/supabase/functions/notification-failed-missions/deno.lock
@@ -1,14 +1,37 @@
 {
   "version": "4",
   "specifiers": {
+    "jsr:@supabase/functions-js@*": "2.4.4",
+    "jsr:@supabase/supabase-js@2": "2.49.4",
     "npm:@supabase/auth-js@2.67.3": "2.67.3",
+    "npm:@supabase/auth-js@2.69.1": "2.69.1",
     "npm:@supabase/functions-js@2.4.4": "2.4.4",
     "npm:@supabase/node-fetch@2.6.15": "2.6.15",
     "npm:@supabase/postgrest-js@1.17.10": "1.17.10",
+    "npm:@supabase/postgrest-js@1.19.4": "1.19.4",
     "npm:@supabase/realtime-js@2.11.2": "2.11.2",
     "npm:@supabase/storage-js@2.7.1": "2.7.1",
     "npm:firebase-admin@*": "13.2.0",
     "npm:openai@^4.52.5": "4.86.2"
+  },
+  "jsr": {
+    "@supabase/functions-js@2.4.4": {
+      "integrity": "38456509a6e22fb116b118464cbb36357256f9048d3580632b63af91f63769f7",
+      "dependencies": [
+        "npm:openai"
+      ]
+    },
+    "@supabase/supabase-js@2.49.4": {
+      "integrity": "4b785f9cd4a62feb7b3f84606bb923a4ea51e3e000eafff0972bc779240b7592",
+      "dependencies": [
+        "npm:@supabase/auth-js@2.69.1",
+        "npm:@supabase/functions-js@2.4.4",
+        "npm:@supabase/node-fetch",
+        "npm:@supabase/postgrest-js@1.19.4",
+        "npm:@supabase/realtime-js",
+        "npm:@supabase/storage-js"
+      ]
+    }
   },
   "npm": {
     "@fastify/busboy@3.1.1": {
@@ -177,6 +200,12 @@
         "@supabase/node-fetch"
       ]
     },
+    "@supabase/auth-js@2.69.1": {
+      "integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
     "@supabase/functions-js@2.4.4": {
       "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
       "dependencies": [
@@ -191,6 +220,12 @@
     },
     "@supabase/postgrest-js@1.17.10": {
       "integrity": "sha512-GlcwOjEmPcXfaEU0wHg1MgHU+peR+zZFyaEWjr7a7EOCB1gCtw3nW7ABfnPPH411coXHV90eb/isDgT9HRshLg==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/postgrest-js@1.19.4": {
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
       "dependencies": [
         "@supabase/node-fetch"
       ]


### PR DESCRIPTION
## 요약

현재는 미션을 실패할 경우 1분 간격으로 조력자에게 알림이 갑니다. 
10분 간격으로 알림이 가도록 수정합니다.

## 작업 내용

- [feat: 조력자에게 실패 알림이 10분 간격으로 보내지게끔 수정](https://github.com/buku-buku/notiyou-supabase-edge-fns/pull/8/commits/b36bb1a6f63846e5b8446a6660737a4adafa1c14)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved notification system to prevent repeated failure notifications within a 10-minute window.
  - Notifications now include a notification type for better clarity.

- **Bug Fixes**
  - Ensured notifications are only sent for overdue and not recently notified missions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->